### PR TITLE
Force publishing octomap topics even if octomap data is empty

### DIFF
--- a/octomap_mapping/CMakeLists.txt
+++ b/octomap_mapping/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(octomap_mapping)
+project(h6x_octomap_mapping)
 find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)

--- a/octomap_mapping/package.xml
+++ b/octomap_mapping/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>octomap_mapping</name>
+  <name>h6x_octomap_mapping</name>
   <version>2.3.0</version>
   <description>
     Mapping tools to be used with the <a href="https://octomap.github.io/">OctoMap library</a>, implementing a 3D occupancy grid mapping.
@@ -15,7 +15,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>octomap_server</exec_depend>
+  <exec_depend>h6x_octomap_server</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/octomap_server/CMakeLists.txt
+++ b/octomap_server/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(octomap_server)
+project(h6x_octomap_server)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/octomap_server/package.xml
+++ b/octomap_server/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>octomap_server</name>
+  <name>h6x_octomap_server</name>
   <version>2.3.0</version>
   <description>
     octomap_server loads a 3D map (as Octree-based OctoMap) and distributes it to other nodes in a compact binary format. It also allows to incrementally build 3D OctoMaps, and provides map saving in the node octomap_saver.

--- a/octomap_server/src/octomap_server.cpp
+++ b/octomap_server/src/octomap_server.cpp
@@ -623,11 +623,12 @@ void OctomapServer::publishAll(const rclcpp::Time & rostime)
 {
   const auto start_time = rclcpp::Clock{}.now();
   const size_t octomap_size = octree_->size();
-  // TODO(someone): estimate num occ. voxels for size of arrays (reserve)
-  if (octomap_size <= 1) {
-    RCLCPP_WARN(get_logger(), "Nothing to publish, octree is empty");
-    return;
-  }
+  // HarvestX: commented the following lines out to force this node to publish the topic
+  // even if octomap is empty
+  //if (octomap_size <= 1) {
+  //  RCLCPP_WARN(get_logger(), "Nothing to publish, octree is empty");
+  //  return;
+  //}
 
   bool publish_free_marker_array_ = publish_free_space_ &&
     (latched_topics_ ||


### PR DESCRIPTION
What is changed:

- Added `h6x_` suffix to octomap_mapping and octomap_server to avoid name collision with the original packages
- Commented out the if statement that skips the publish of topics when octomap is empty