### PR TITLE
Disable tf transform timeout

### DIFF
--- a/octomap_server/package.xml
+++ b/octomap_server/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>h6x_octomap_server</name>
-  <version>2.3.0</version>
+  <version>2.3.1</version>
   <description>
     octomap_server loads a 3D map (as Octree-based OctoMap) and distributes it to other nodes in a compact binary format. It also allows to incrementally build 3D OctoMaps, and provides map saving in the node octomap_saver.
   </description>

--- a/octomap_server/src/octomap_server.cpp
+++ b/octomap_server/src/octomap_server.cpp
@@ -432,8 +432,7 @@ void OctomapServer::insertCloudCallback(const PointCloud2::ConstSharedPtr cloud)
     geometry_msgs::msg::TransformStamped base_to_world_transform_stamped;
     try {
       tf2_buffer_->canTransform(
-        base_frame_id_, cloud->header.frame_id, cloud->header.stamp,
-        rclcpp::Duration::from_seconds(0.2));
+        base_frame_id_, cloud->header.frame_id, cloud->header.stamp);
       sensor_to_base_transform_stamped = tf2_buffer_->lookupTransform(
         base_frame_id_, cloud->header.frame_id, cloud->header.stamp);
       base_to_world_transform_stamped = tf2_buffer_->lookupTransform(

--- a/octomap_server/src/octomap_server.cpp
+++ b/octomap_server/src/octomap_server.cpp
@@ -407,8 +407,7 @@ void OctomapServer::insertCloudCallback(const PointCloud2::ConstSharedPtr cloud)
   geometry_msgs::msg::TransformStamped sensor_to_world_transform_stamped;
   try {
     sensor_to_world_transform_stamped = tf2_buffer_->lookupTransform(
-      world_frame_id_, cloud->header.frame_id, cloud->header.stamp,
-      rclcpp::Duration::from_seconds(1.0));
+      world_frame_id_, cloud->header.frame_id, cloud->header.stamp);
   } catch (const tf2::TransformException & ex) {
     RCLCPP_WARN(this->get_logger(), "%s", ex.what());
     return;
@@ -436,11 +435,9 @@ void OctomapServer::insertCloudCallback(const PointCloud2::ConstSharedPtr cloud)
         base_frame_id_, cloud->header.frame_id, cloud->header.stamp,
         rclcpp::Duration::from_seconds(0.2));
       sensor_to_base_transform_stamped = tf2_buffer_->lookupTransform(
-        base_frame_id_, cloud->header.frame_id, cloud->header.stamp,
-        rclcpp::Duration::from_seconds(1.0));
+        base_frame_id_, cloud->header.frame_id, cloud->header.stamp);
       base_to_world_transform_stamped = tf2_buffer_->lookupTransform(
-        world_frame_id_, base_frame_id_, cloud->header.stamp,
-        rclcpp::Duration::from_seconds(1.0));
+        world_frame_id_, base_frame_id_, cloud->header.stamp);
     } catch (const tf2::TransformException & ex) {
       RCLCPP_ERROR_STREAM(
         get_logger(),

--- a/octomap_server/src/octomap_server_multilayer.cpp
+++ b/octomap_server/src/octomap_server_multilayer.cpp
@@ -118,8 +118,7 @@ void OctomapServerMultilayer::handlePreNodeTraversal(const rclcpp::Time & rostim
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
       transform_stamped = tf2_buffer_->lookupTransform(
-        "base_footprint", arm_links_.at(i), rclcpp::Time(0),
-        rclcpp::Duration::from_seconds(1.0));
+        "base_footprint", arm_links_.at(i), rclcpp::Time(0));
     } catch (const tf2::TransformException & ex) {
       RCLCPP_WARN(this->get_logger(), "%s", ex.what());
       return;


### PR DESCRIPTION
This pull request updates the way transform lookups are performed in both `octomap_server.cpp` and `octomap_server_multilayer.cpp`. The main change is the removal of explicit timeout durations from calls to `tf2_buffer_->lookupTransform` and `tf2_buffer_->canTransform`, which simplifies the transform queries and relies on default behavior.

Transform lookup simplification:

* Removed explicit timeout durations from `tf2_buffer_->lookupTransform` and `tf2_buffer_->canTransform` calls in `OctomapServer::insertCloudCallback`, streamlining transform queries for sensor and base frames. 
* Removed explicit timeout duration from `tf2_buffer_->lookupTransform` in `OctomapServerMultilayer::handlePreNodeTraversal`, simplifying transform retrieval for arm links.